### PR TITLE
prefer-ldrize greasemonkey 0.9.* 対応

### DIFF
--- a/plugins/prefer-ldrize.ks.js
+++ b/plugins/prefer-ldrize.ks.js
@@ -425,6 +425,7 @@ var preferLDRize =
 
              try
              {
+                 sandbox = (sandbox.window) ? sandbox : codebase;
 
                  if (sandbox.window.Minibuffer != undefined && sandbox.window.LDRize != undefined)
                  {


### PR DESCRIPTION
たびたびすみません
グリモン 0.9 以上を使っていて http://d.hatena.ne.jp/wlt/20110130/1296359063 のパッチが当たっている際におかしかったのを修正しました
判定方法がちょっとアレですが・・・
よろしければマージお願いします
