### PR TITLE
yatck: Filter official/unofficial RTs on word tracking results. Fix #62

### DIFF
--- a/plugins/yet-another-twitter-client-keysnail.ks.js
+++ b/plugins/yet-another-twitter-client-keysnail.ks.js
@@ -1435,7 +1435,7 @@ var twitterClient =
                     interval     : infoHolder["interval"] || pOptions["tracking_update_interval"],
                     oauth        : gOAuth,
                     countName    : "rpp",
-                    mapper       : function (response) response.results.map(filterSearchResult),
+                    mapper       : function (response) response.results.filter( function (st) {return st.text.indexOf("RT @") !== 0;} ).map(filterSearchResult),
                     getLastID    : function () infoHolder["lastID"],
                     setLastID    : function (v) {
                         infoHolder["lastID"] = v;


### PR DESCRIPTION
RTs are just marked with prefix "RT @"...
There is no method to detect whether it is official or unofficial.