### PR TITLE
Add an option for not using j.mp

### DIFF
--- a/plugins/yet-another-twitter-client-keysnail.ks.js
+++ b/plugins/yet-another-twitter-client-keysnail.ks.js
@@ -2762,7 +2762,24 @@ var twitterClient =
                 cursorEnd    : aCursorEnd,
                 onChange     : function (arg) {
                     var current = arg.textbox.value;
-                    var length  = current.length;
+
+                    // take t.co shorten into account
+                    // https://dev.twitter.com/blog/next-steps-with-the-tco-link-wrapper
+                    var regex  = /(?:https?\:\/\/|www\.)[^\s]+/g;
+                    var noURL  = current.replace(regex, "");
+                    var URLs   = current.match(regex);
+                    var length = noURL.length;
+
+                    if (URLs) {
+                        URLs.forEach(function (url) {
+                            if (url.match("https://")){
+                                length += 21;
+                            } else {
+                                length += 20;
+                            }
+                        });
+                    }
+
                     var count   = limit - length;
                     var msg     = M({ja: ("残り " + count + " 文字"), en: count});
 


### PR DESCRIPTION
Twitter API がすべての URL を自動で t.co に短縮するようになったことに対応し、j.mp によるトラッキングを必要としないユーザのために、圧縮しないオプションをもうけました。

URL は生のままポストされますが、いちおう URL を考慮して文字数をカウントするので、文字数オーバーになるかはある程度予測できます。
