### PR TITLE
yatck: fix a bug by strictly checking the array length: aOld[0] can be undefined

### DIFF
--- a/plugins/yet-another-twitter-client-keysnail.ks.js
+++ b/plugins/yet-another-twitter-client-keysnail.ks.js
@@ -1116,7 +1116,7 @@ var twitterClient =
             function combineCache(aNew) {
                 var aOld = this.cache;
 
-                if (!aOld)
+                if (!aOld.length)
                     return aNew;
 
                 if (share.twitterImmediatelyAddedStatuses.length)


### PR DESCRIPTION
トラッキングワードの結果がない状態で、リロードした時にエラーをだしていたので、修正しました。
