### PR TITLE
Fix bug that aOld is undefined on startup.

### DIFF
--- a/plugins/yet-another-twitter-client-keysnail.ks.js
+++ b/plugins/yet-another-twitter-client-keysnail.ks.js
@@ -1116,7 +1116,7 @@ var twitterClient =
             function combineCache(aNew) {
                 var aOld = this.cache;
 
-                if (!aOld.length)
+                if (!aOld || !aOld.length)
                     return aNew;
 
                 if (share.twitterImmediatelyAddedStatuses.length)


### PR DESCRIPTION
Fix bug that aOld is undefined, and does not have the length property on startup.

前の修正で aOld についての判定をやめてしまったことで、起動時に TL をロードできない問題をおこしてしまいました。
