### PR TITLE
yatck: implement filters (experimental)

### DIFF
--- a/plugins/yet-another-twitter-client-keysnail.ks.js
+++ b/plugins/yet-another-twitter-client-keysnail.ks.js
@@ -465,6 +465,11 @@ let pOptions = plugins.setupOptions("twitter_client", {
         preset: false,
         description: M({ ja: "ツイート入力時に自分のスクリーン名を表示する",
                          en: "Display your screen name in tweet box." })
+    },
+    "filters"                               : {
+        preset: [],
+        description: M({ ja: "登録された関数に status をわたし、 true を返した tweet を消します",
+                         en: "Remove tweets when one of the functions returns true." })
     }
 }, PLUGIN_INFO);
 
@@ -3258,6 +3263,10 @@ var twitterClient =
 
             // ignore black users
             var statuses = options.supressFilter ? aStatuses : aStatuses.filter(notBlack);
+
+            pOptions["filters"].forEach( function(filter_func){
+                statuses = statuses.filter(filter_func);
+            });
 
             // ============================================================ //
 


### PR DESCRIPTION
Setting sample: https://gist.github.com/1164439

This is just a basic implementation. Lots of space for improvement.
I want to get ideas.

Homeline, 検索, Mention などでフィルタをきりかえたいかなとも思うんですが、ひとまずベーシックな実装をしてみました。
statuses をまるごと渡して、削除以外に文字列処理などもできるような設計もあると思うんですが、どうでしょう。
ご意見をうかがいたいです。
