### PR TITLE
Add command to stop / restart home_timeline update

### DIFF
--- a/plugins/yet-another-twitter-client-keysnail.ks.js
+++ b/plugins/yet-another-twitter-client-keysnail.ks.js
@@ -1712,7 +1712,15 @@ var twitterClient =
             [function (status) {
                  switchTo();
              }, M({ja: "移動 (リスト, Home, Mentions, ...)", en: "Switch to (Lists, Home, Mentions, ...)"}),
-             "switch-to"]
+             "switch-to"],
+            [function (status) {
+                if (gStatuses.updater) {
+                    gStatuses.stop();
+                } else {
+                    gStatuses.update(0, false, false);
+                }
+             }, M({ja: "home timeline の自動読み込みきりかえ", en: "Toggle auto-update of home timeline"}),
+             "toggle-homeline-updating"]
         ];
 
         // }} ======================================================================= //


### PR DESCRIPTION
When you concentrate, you should turn off twitter update.
But it cannot be fully turned off, because you can get important messages via Mention or DM.
This add a point to stop only home_timeline.

```
plugins.options["twitter_client.keymap"] = {
    "x"     : "toggle-homeline-updating"
};
```
