### PR TITLE
Fix: HoK hints don't disappear when you open a link in a new tab with the unique_fire option disabled

### DIFF
--- a/plugins/hok.ks.js
+++ b/plugins/hok.ks.js
@@ -1087,9 +1087,13 @@ var hok = function () {
                 updateHeaderMatchHints();
             return;
         case 'Enter':
-            if (lastMatchHint)
-                fire(lastMatchHint.element);
-            destruction();
+            if (lastMatchHint) {
+                let elem = lastMatchHint.element;
+                destruction();
+                fire(elem);
+            } else {
+                destruction();
+            }
             return;
         default :
             inputKey += role;


### PR DESCRIPTION
This is due to `destruction()` being called _after_ the focus moves to the newly opened tab. I've just fixed it.
