### PR TITLE
HoK: Make respond to `title` or `alt`

### DIFF
--- a/plugins/hok.ks.js
+++ b/plugins/hok.ks.js
@@ -448,7 +448,7 @@ const pOptions = plugins.setupOptions("hok", {
     },
 
     "follow_link_candidate_selector": {
-        preset: "a[href], input:not([type='hidden']), button"
+        preset: "a[href], input:not([type='hidden']), button, img[alt]"
     }
 }, PLUGIN_INFO);
 
@@ -567,7 +567,9 @@ function followRel(doc, rel, pattern) {
     );
 
     for (let [, elem] in Iterator(relLinkCandidates.reverse())) {
-        if (relLinkPattern.test(elem.textContent) /*|| regex.test(elem.value) */) {
+        if (relLinkPattern.test(elem.textContent) ||
+            relLinkPattern.test(elem.alt) ||
+            relLinkPattern.test(elem.title)) {
             followLink(elem, CURRENT_TAB);
             return;
         }


### PR DESCRIPTION
I wish to follow a link by HoK with (not only a `textContent` property but also) a `title` or an `alt` attribute in such as a fragment of a document as shown below:

    <ul>
        <li><a title="Next"><img src="./foobar/next.png" alt="" /></a></li>
        <li><a title="Previous"><img src="./foobar/prev.png" alt="" /></a></li>
    </ul>

Therefore, I send a simple Pull Request to actualize it.
I would be grateful if you could merge it.

Thank you for your cooperation. 


P.S.

I am awfully sorry but I am not quite understand what the following commented out condition is.

    /*|| regex.test(elem.value) */

I had a hard time detecting (by `git blame`) how did it come about.