### PR TITLE
fix for removal of support for let expressions from spider monkey

### DIFF
--- a/share/functions.js
+++ b/share/functions.js
@@ -157,7 +157,9 @@ var ksBuiltin = {
 
         focus_to_content: [
             function (ev, arg) {
-                let (elem = document.commandDispatcher.focusedElement) elem && elem.blur();
+                let (elem = document.commandDispatcher.focusedElement) {
+                    elem && elem.blur();
+                }
                 gBrowser.focus();
                 content.focus();
             }, true],
@@ -286,10 +288,12 @@ var ksBuiltin = {
         open_url_from_clipboard: [
             function (ev, arg) {
                 gBrowser.loadOneTab(
-                    let (url = command.getClipboardText())
+                    let (url = command.getClipboardText()) {
                         url.indexOf("://") === -1 ?
-                        util.format("http://www.google.com/search?q=%s&ie=utf-8&oe=utf-8", encodeURIComponent(url)) :
-                        url,
+                            util.format("http://www.google.com/search?q=%s&ie=utf-8&oe=utf-8",
+                                        encodeURIComponent(url)) :
+                            url
+                    },
                     null, null, null, false
                 );
             }, false
@@ -298,10 +302,11 @@ var ksBuiltin = {
         open_url_from_selection_clipboard: [
             function (ev, arg) {
                 gBrowser.loadOneTab(
-                    let (url = command.getClipboardText(true))
+                    let (url = command.getClipboardText(true)) {
                         url.indexOf("://") === -1 ?
-                        util.format("http://www.google.com/search?q=%s&ie=utf-8&oe=utf-8", encodeURIComponent(url)) :
-                        url,
+                            util.format("http://www.google.com/search?q=%s&ie=utf-8&oe=utf-8", encodeURIComponent(url)) :
+                            url
+                    },
                     null, null, null, false
                 );
             }, false
@@ -491,8 +496,9 @@ var ksBuiltin = {
                 if (!command.kill.ring.length)
                     return;
 
-                let (ct = command.getClipboardText())
+                let (ct = command.getClipboardText()) {
                     (!command.kill.ring.length || ct != command.kill.ring[0]) && command.pushKillRing(ct);
+                }
 
                 prompt.selector(
                     {


### PR DESCRIPTION
Keysnail stopped working for me after ubuntu updated my firefox to version 41.0.
Got an error referring to a missing '{' near a let block. Fixed my .keysnail.js file locally.
A bit of searching got me the link referenced in the commit message. Found it via https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let in the section on 'let expressions'.