### PR TITLE
Support Firefx 46

### DIFF
--- a/components/keysnail-loader.js
+++ b/components/keysnail-loader.js
@@ -113,7 +113,7 @@ KeySnailLoader.prototype = {
 
         let context = win.KeySnail.modules;
 
-        for (let [, module] in Iterator(modules))
+        for (let module of modules)
             loadModule(module, context);
     },
 
@@ -122,7 +122,7 @@ KeySnailLoader.prototype = {
                      "password1Container",
                      "password2Container"];
 
-        for (let [, id] in Iterator(ids))
+        for (let id of ids)
         {
             let elem = aDocument.getElementById(id);
             if (elem && !elem.hidden)

--- a/content/keysnail.js
+++ b/content/keysnail.js
@@ -101,7 +101,7 @@
                 _ = modules._;
             } catch (x) {}
 
-            for (let [, name] in Iterator(moduleObjects))
+            for (let name of moduleObjects)
                 this.initModule(name);
 
             // set modules
@@ -593,7 +593,7 @@
                 if (pluginUpdater.checking)
                     return;
 
-                let paths = [path for ([path, plugin] in Iterator(plugins.context))];
+                let paths = [for (path of Object.keys(plugins.context)) path];
 
                 pluginUpdater.checking = true;
                 pluginUpdater.pluginsWithUpdate = [];

--- a/content/modules/command.js
+++ b/content/modules/command.js
@@ -346,7 +346,7 @@ var command = {
             return node && /^(https?|ftp):/.test(node.uri);
         }
 
-        var urlList = [getInfo(item) for ([, item] in Iterator(items)) if (isBookmarkItem(item))];
+        var urlList = [for (item of items) if (isBookmarkItem(item)) getInfo(item)];
 
         prompt.selector(
             {

--- a/content/modules/ext.js
+++ b/content/modules/ext.js
@@ -25,7 +25,7 @@ var ext = function () {
         }
         keyList = keyList.sort();
 
-        for (let [, name] in Iterator(keyList))
+        for (let name of keyList)
             extList.push([name, exts[name].description || ""]);
 
         return extList;

--- a/content/modules/hook.js
+++ b/content/modules/hook.js
@@ -54,7 +54,7 @@ var hook = {
         if (!hook)
             return;
 
-        for (let [i, action] in Iterator(hook)) {
+        for (let [i, action] of util.keyValues(hook)) {
             try {
                 action(arg);
             } catch (x) {

--- a/content/modules/key.js
+++ b/content/modules/key.js
@@ -371,8 +371,8 @@ var key = {
 
         this.passAllKeys = true;
 
-        for (let [, keyStr] in Iterator(aKeys)) {
-            for (let [, type] in Iterator(aType)) {
+        for (let keyStr of aKeys) {
+            for (let type of aType) {
                 util.message("feed " + keyStr);
                 let event = this.stringToKeyEvent(keyStr, true, type, true);
                 // event.ksNoHandle becomes undefined while propagating
@@ -1049,7 +1049,7 @@ var key = {
         var aTarget = this.keyMapHolder[aTargetKeyMapName];
         var aDestination = this.keyMapHolder[aDestinationKeyMapName];
 
-        for (let [property, value] in Iterator(aTarget))
+        for (let [property, value] of util.keyValues(aTarget))
             aDestination[property] = value;
     },
 
@@ -1104,7 +1104,7 @@ var key = {
         if (!(aKeyMapName instanceof Array))
             aKeyMapName = [aKeyMapName];
 
-        for (let [, keyMapName] in Iterator(aKeyMapName))
+        for (let keyMapName of aKeyMapName)
         {
             var addTo = this.keyMapHolder[keyMapName];
 
@@ -1348,7 +1348,7 @@ var key = {
         if (!aKeySequence)
             aKeySequence = [];
 
-        for (let [keyStr, cont] in Iterator(aKeyMap))
+        for (let [keyStr, cont] of util.keyValues(aKeyMap))
         {
             switch (typeof cont)
             {

--- a/content/modules/macro.js
+++ b/content/modules/macro.js
@@ -34,7 +34,7 @@ var macro = {
         var len = aEvents.length;
         var sleepTime = this.sleepTime;
 
-        for (let [, event] in Iterator(aEvents))
+        for (let event of aEvents)
         {
             if (event.keyCode === KeyEvent.DOM_VK_TAB)
             {

--- a/content/modules/plugins.js
+++ b/content/modules/plugins.js
@@ -17,7 +17,7 @@ var plugins = {
     setupOptions: function (prefix, defaults, pluginInfo) {
         let options = {};
 
-        for (let [name, { preset, description, type, hidden }] in Iterator(defaults)) {
+        for (let [name, { preset, description, type, hidden }] of util.keyValues(defaults)) {
             let fullName = prefix + "." + name;
 
             // XXX: bind values
@@ -107,7 +107,7 @@ var plugins = {
     getInstalledPlugins: function () {
         let pluginList = {};
 
-        for (let [pluginPath, pluginContext] in Iterator(plugins.context)) {
+        for (let [pluginPath, pluginContext] of util.keyValues(plugins.context)) {
             let isDisabled      = userscript.isDisabledPlugin(pluginPath);
             let isNotCompatible = pluginContext.__ksNotCompatible__;
 

--- a/content/modules/prompt.js
+++ b/content/modules/prompt.js
@@ -164,19 +164,19 @@ var prompt = function () {
     function $E(aName, aAttributes) {
         let elem = document.createElement(aName);
 
-        for (let [k, v] in Iterator(aAttributes))
+      for (let [k, v] of util.keyValues(aAttributes))
             elem.setAttribute(k, v);
 
         return elem;
     }
 
     function implant(a, b) {
-        for (let [k, v] in Iterator(b))
+        for (let [k, v] of util.keyValues(b))
             a[k] = v;
     }
 
     function implantAll(a, b) {
-        for (let k in util.getAllPropertyNames(b)) {
+        for (let k of util.getAllPropertyNames(b)) {
             try {
                 a[k] = b[k];
             } catch (_) {}
@@ -193,10 +193,10 @@ var prompt = function () {
         var newObject = {};
         var key;
 
-        for (let [key, value] in Iterator(a))
+        for (let [key, value] of util.keyValues(a))
             newObject[key] = value;
 
-        for (let [key, value] in Iterator(b))
+        for (let [key, value] of util.keyValues(b))
             newObject[key] = value;
 
         return newObject;
@@ -210,7 +210,7 @@ var prompt = function () {
 
     function getActualCols(aCols) {
         if (gFlags)
-            for (let [, flag] in Iterator(gFlags))
+            for (let flag of gFlags)
                 if (flag & (HIDDEN | ICON)) aCols--;
         return aCols;
     }
@@ -259,7 +259,7 @@ var prompt = function () {
     function setColumns(aColumn) {
         if (gFlags)
         {
-            for (let [, flag] in Iterator(gFlags))
+            for (let flag of gFlags)
             {
                 if (flag & (HIDDEN | ICON))
                     aColumn--;
@@ -726,7 +726,7 @@ var prompt = function () {
             var found   = {};
             var uniqStr = "";
 
-            for (let [, c] in Iterator(str))
+            for (let c of str)
             {
                 if (found[c])
                     continue;
@@ -749,7 +749,7 @@ var prompt = function () {
 
         var continuousMode = false;
 
-        for (let [, opt] in Iterator(uniq(opts)))
+        for (let opt of uniq(opts))
         {
             switch (opt)
             {
@@ -1016,7 +1016,7 @@ var prompt = function () {
         if (typeof aActions === "function")
             aActions = [[aActions, "Default callback"]];
 
-        for (let [i, action] in Iterator(aActions))
+        for (let [i, action] of util.keyValues(aActions))
         {
             var item = document.createElement("menuitem");
             item.setAttribute("label", action[1]);
@@ -1047,7 +1047,7 @@ var prompt = function () {
         );
 
         function stick(keymap) {
-            for (let [k, a] in Iterator(keymap))
+            for (let [k, a] of util.keyValues(keymap))
             {
                 let act  = a.split(",")[0];
                 let desc = actionDescriptionMap[act] || "";
@@ -1091,7 +1091,7 @@ var prompt = function () {
         var list = [];
 
         // create action list and local command
-        for (let [i, action] in Iterator(aActions))
+        for (let [i, action] of util.keyValues(aActions))
         {
             let index = i + 1;
             list.push([action[0], index.toString() + ". " + action[1]]);
@@ -1201,7 +1201,7 @@ var prompt = function () {
                     }
                 }).filter(function (r) r);
 
-            var cellForSearch = gFlags ? [i for (i in gFlags) if ((gFlags[i] & IGNORE) === 0)] : null;
+            var cellForSearch = gFlags ? [for (i of Object.keys(gFlags)) if ((gFlags[i] & IGNORE) === 0) i] : null;
 
             // reduce prototype chaine
             let list  = wholeList;
@@ -1456,7 +1456,7 @@ var prompt = function () {
                 let buffer   = [];
                 let escapeIt = false;
 
-                for (let [, c] in Iterator(str))
+                for (let c of str)
                 {
                     if (!escapeIt && c === escapeChar)
                         escapeIt = true;
@@ -1734,7 +1734,7 @@ var prompt = function () {
                     collection : null
                 };
 
-                for (let [, cmpltr] in Iterator(completers))
+                for (let cmpltr of completers)
                 {
                     let tmpCc      = cmpltr(currentText, text) || {collection : null};
                     let collection = tmpCc.collection;
@@ -1749,7 +1749,7 @@ var prompt = function () {
 
                 let max = -1;
 
-                for (let [, c] in Iterator(collections))
+                for (let c of collections)
                 {
                     let first = c[0];
 
@@ -1797,8 +1797,8 @@ var prompt = function () {
                     context.text = left;
 
                     let tabs       = getBrowser().mTabContainer.childNodes;
-                    let collection = [[tab.image, tab.label, tab.linkedBrowser.contentDocument.URL]
-                                      for ([, tab] in Iterator(Array.slice(tabs)))];
+                    let collection = [for (tab of Array.slice(tabs))
+                                      [tab.image, tab.label, tab.linkedBrowser.contentDocument.URL]];
 
                     let cc    = completer.matcher.migemo(collection, {multiple:true})(left, whole);
                     cc.flags  = [ICON | IGNORE, 0, 0];
@@ -1964,12 +1964,12 @@ var prompt = function () {
                                 "watch"                : undefined
                             };
 
-                            for (let k in Iterator(objectPrototype, true))
+                            for (let k of Object.keys(objectPrototype))
                                 objectPrototype[k] = Object[k];
 
                             let functionPrototype = {__proto__ : objectPrototype};
 
-                            for (let [, k] in Iterator(["apply", "call", "toSource", "toString", "valueOf"]))
+                            for (let  k of ["apply", "call", "toSource", "toString", "valueOf"])
                                 functionPrototype[k] = Function[k];
 
                             let globalObjects = {
@@ -1994,11 +1994,11 @@ var prompt = function () {
                                 URIError       : []
                             };
 
-                            for (let [objName, keys] in Iterator(globalObjects))
+                            for (let [objName, keys] of util.keyValues(globalObjects))
                             {
                                 globalObjects[objName] = {};
 
-                                for ([, k] in Iterator(keys))
+                                for (k of keys)
                                 {
                                     globalObjects[objName][k] = global[objName][k];
                                 }
@@ -2214,8 +2214,7 @@ var prompt = function () {
                     if (!query)
                     {
                         cc.collection =
-                            [getRow(root, k)
-                             for (k in util.getAllPropertyNames(root))].sort(cmp);
+                            [for (k of util.getAllPropertyNames(root)) getRow(root, k)].sort(cmp);
                         return cc;
                     }
                     else
@@ -2263,12 +2262,11 @@ var prompt = function () {
                         {
                             if (all)
                             {
-                                cc.collection = [getRow(obj, k, prefix)
-                                                 for (k in util.getAllPropertyNames(obj))].sort(cmp);
+                                cc.collection = [for (k of util.getAllPropertyNames(obj)) getRow(obj, k, prefix)].sort(cmp);
                             }
                             else
                             {
-                                let keys    = [(k || "") for (k in util.getAllPropertyNames(obj))];
+                                let keys    = [for (k of util.getAllPropertyNames(obj)) (k || "")];
                                 let matched = [];
 
                                 // head
@@ -2289,7 +2287,7 @@ var prompt = function () {
                                                        return true;
                                                    });
 
-                                cc.collection = [getRow(obj, k, prefix) for each (k in matched)];
+                                cc.collection = [for (k of matched) getRow(obj, k, prefix)];
                             }
                         }
 
@@ -2828,7 +2826,7 @@ var prompt = function () {
                     hook.removeHook('KeySnailInitialized', onInitialized);
                     let displayHelpKey = [];
 
-                    for (let [k, act] in Iterator(actionKeys.selector))
+                    for (let [k, act] of util.keyValues(actionKeys.selector))
                     {
                         if (act === "prompt-display-keymap-help")
                             displayHelpKey.push(k);

--- a/content/modules/shell.js
+++ b/content/modules/shell.js
@@ -317,7 +317,7 @@ var shell =
           * @param {} b
           */
          function implant(a, b) {
-             for (let [k, v] in Iterator(a))
+             for (let [k, v] of util.keyValues(a))
                  b[k] = v;
 
              return b;
@@ -443,7 +443,7 @@ var shell =
                          argCount  : "1",
                          options   : [[["-prefix-arguments", "-pa"], option.INT, null]],
                          completer : function (args, extra) completer.matcher.header(
-                             [[n, ext.description(n)] for (n in ext.exts)].sort(util.sortMultiple),
+                             [for (n of Object.keys(ext.exts)) [n, ext.description(n)]].sort(util.sortMultiple),
                              { style : ["", style.prompt.description] }
                          )(extra.left, extra.whole)
                      });
@@ -480,7 +480,7 @@ var shell =
                                  //     if user input
                                  //        "h" <TAB>
                                  //     returned item is will be "hoge".
-                                 for ([name, cmd] in Iterator(commands))
+                                 for (let [name, cmd] of util.keyValues(commands))
                                  {
                                      if (name.indexOf(left) === 0)
                                      {

--- a/content/modules/userscript.js
+++ b/content/modules/userscript.js
@@ -777,7 +777,7 @@ var userscript = {
             main: "chrome://browser/content/browser.xul"
         };
 
-        for (let [, entry] in Iterator(includeURIs))
+        for (let entry of includeURIs)
         {
             uri = replacePair[entry] || entry;
 
@@ -785,7 +785,7 @@ var userscript = {
                 return false;
         }
 
-        for (let [, entry] in Iterator(excludeURIs))
+        for (let entry of excludeURIs)
         {
             uri = replacePair[entry] || entry;
 
@@ -1318,9 +1318,9 @@ var userscript = {
             'negativeArgument3'
         ];
 
-        var maxLen = Math.max.apply(null, [str.length for each (str in keys)]);
+        var maxLen = Math.max.apply(null, [for (str of keys) str.length]);
 
-        for (let [, key] in Iterator(keys))
+        for (let key of keys)
         {
             var setting = settings[key] || "undefined";
             var padding = Math.max(maxLen - key.length, 0) + 2;
@@ -1335,7 +1335,7 @@ var userscript = {
             return;
         }
 
-        for (let [, setting] in Iterator(aScheme.hooks))
+        for (let setting of aScheme.hooks)
         {
             let [name, body] = setting;
             if (!name || !body)
@@ -1376,7 +1376,7 @@ var userscript = {
         function getFunction(aCommand) {
             if (typeof aCommand === "string")
             {
-                for (let [, commands] in Iterator(builtin))
+                for (let commands of util.values(builtin))
                 {
                     if (commands[aCommand])
                         return commands[aCommand][0].toString();
@@ -1420,7 +1420,7 @@ var userscript = {
 
             var settings = aScheme.keybindings[mode];
 
-            for (let [, setting] in Iterator(settings))
+            for (let setting of settings)
             {
                 if (!setting)
                     continue;

--- a/content/modules/util.js
+++ b/content/modules/util.js
@@ -35,7 +35,7 @@ var util = function () {
 
                 // partially borrowed from bookmarks.js of liberator
                 ensureAliases : function (aEngines) {
-                    for (let [, engine] in Iterator(aEngines))
+                    for (let engine of aEngines)
                     {
                         if (!engine.alias)
                         {
@@ -309,7 +309,7 @@ var util = function () {
                 // returns pair of hex code for given 1 byte
                 function toHexString(charCode) ("0" + charCode.toString(16)).slice(-2);
 
-                return [toHexString(hash.charCodeAt(i)) for (i in hash)].join("");
+                return [for (i of Object.keys(hash)) toHexString(hash.charCodeAt(i))].join("");
             }
 
             return hash;
@@ -445,7 +445,7 @@ var util = function () {
                     }
                 }
 
-                let buffer = [[k, v] for ([k, v] in new Iterator(obj))];
+                let buffer = [for (kv of util.keyValues(obj)) kv];
                 let max    = Math.max.apply(null, buffer.map(function ([k]) (k || "").length));
                 let util   = this;
                 this.message(buffer.map(function ([k, v]) k + util.repeatString(" ", max - k.length) + " : " + getV(v)).join("\n"));
@@ -633,7 +633,7 @@ var util = function () {
          */
         setPrefs:
         function setPrefs(aPrefList) {
-            for (let [key, value] in Iterator(aPrefList))
+            for (let [key, value] of util.keyValues(aPrefList))
                 this.setPref(key, value);
         },
 
@@ -1209,7 +1209,7 @@ var util = function () {
             let pt = typeof prm;
 
             if (prm && pt === "object")
-                prm = [k + "=" + v for ([k, v] in Iterator(prm))].join("&");
+                prm = [for (k of util.keyValues(prm)) k + "=" + v].join("&");
             else if (pt !== "string")
                 prm = "";
 
@@ -1257,7 +1257,7 @@ var util = function () {
             if (opts.mimeType)
                 req.overrideMimeType(opts.mimeType);
 
-            for (let [name, value] in Iterator(opts.header || {}))
+            for (let [name, value] of util.keyValue(opts.header || {}))
                 req.setRequestHeader(name, value);
 
             req.send(util.paramsToString(params) || null);
@@ -1379,7 +1379,7 @@ var util = function () {
                 // nothing
                 break;
             case "object":
-                params = [k + "=" + v for ([k, v] in Iterator(params))].join("&");
+                params = [for (kv of util.keyValues(params)) kv[0] + "=" + kv[1]].join("&");
                 break;
             default:
                 params = "";
@@ -1529,7 +1529,7 @@ var util = function () {
                 if ("getOwnPropertyNames" in Object) {
                     let encountered = { __proto__ : null };
 
-                    for (let [, k] in Iterator(Object.getOwnPropertyNames(obj)))
+                    for (let k of Object.getOwnPropertyNames(obj))
                         try {
                             encountered[k] = true;
                             yield k;
@@ -1549,7 +1549,7 @@ var util = function () {
             }
             catch (x)
             {
-                throw StopIteration;
+                return;
             }
 
             if (wrapped)
@@ -1559,17 +1559,20 @@ var util = function () {
         sortMultiple: function ([a], [b]) { return (a < b) ? -1 : (a > b) ? 1 : 0; },
 
         find: function (array, pred) {
-            for (let [i, v] in Iterator(array))
+            for (let [i, v] of util.keyValues(array)) {
                 if (pred(v, i))
                     return v;
+            }
+            return undefined;
         },
 
         findAll: function (array, pred) {
             let res = [];
 
-            for (let [i, v] in Iterator(array))
+            for (let [i, v] of util.keyValues(array)) {
                 if (pred(v, i))
-                    res.push(v);
+                  res.push(v);
+            }
 
             return res.length ? res : null;
         },
@@ -1630,7 +1633,7 @@ var util = function () {
                 if (this.rangeInterrupted)
                 {
                     this.message("Interrupted");
-                    throw StopIteration;
+                    return;
                 }
                 yield i;
             }
@@ -1642,12 +1645,26 @@ var util = function () {
             g.next();
         },
 
+        keyValues:
+        function keyValues(obj) {
+            for (let k of Object.keys(obj)) {
+                yield [k, obj[k]];
+            }
+        },
+
+        values:
+        function values(obj) {
+            for (let k of Object.keys(obj)) {
+                yield obj[k];
+            }
+        },
+
         // }} ======================================================================= //
 
         // String {{ ================================================================ //
 
         repeatString: function (str, len) {
-            return [str for (i in this.range(0, len))].join("");
+            return [for (i of this.range(0, len)) str].join("");
         },
 
         createSeparator: function (label) {

--- a/content/modules/vimp.js
+++ b/content/modules/vimp.js
@@ -351,7 +351,7 @@ shell.add("dia[log]", "Open a dialog",
 
               try
               {
-                  for (let [, dialog] in Iterator(dialogs))
+                  for (let dialog of dialogs)
                   {
                       if (dialog[0].toLowerCase() === arg.toLowerCase())
                       {
@@ -404,7 +404,7 @@ function getRemotePluginListCached(purgeCache) {
     return remotePluginListCache;
 }
 function getRemotePluginInfoByPluginName(pluginName) {
-    for (let [, remotePluginInfo] in Iterator(getRemotePluginListCached()))
+    for (let remotePluginInfo of getRemotePluginListCached())
         if (remotePluginInfo.leafName === pluginName)
             return remotePluginInfo;
     return null;
@@ -442,8 +442,7 @@ function pluginCompleter(completerArgs, extra) {
         };
         let commands = {};
         Object.assign(commands, commandsNeedPluginCompletion, commandsNoCompletion);
-        cc = completer.matcher.migemo([[name, description]
-                                       for ([name, description] in Iterator(commands))],
+        cc = completer.matcher.migemo([for (kv of util.keyValues(commands)) kv],
                                       null)(left);
     } else if (args.length >= 1 && commandsNeedPluginCompletion.hasOwnProperty(args[0])) {
         /* List plugin names */
@@ -478,9 +477,9 @@ function pluginCompleter(completerArgs, extra) {
                 header   : ["Name", "Description", "Author"],
                 multiple : true
             };
-            pluginList = [[
+            pluginList = [for (pluginInfo of getRemotePluginListCached()) [
                 pluginInfo.iconURL, pluginInfo.leafName, pluginInfo.description, pluginInfo.authorName
-            ] for ([, pluginInfo] in Iterator(getRemotePluginListCached()))];
+            ]];
         } else {
             /* list installed plugins */
             let installedPluginTable = plugins.getInstalledPlugins();
@@ -496,10 +495,12 @@ function pluginCompleter(completerArgs, extra) {
                 multiple : true
             };
 
-            pluginList = [[
-                pluginInfo.iconURL, pluginName, pluginInfo.description
-            ] for ([pluginName, {pluginPath, pluginInfo}] in Iterator(installedPluginTable))
-              if (pluginShouldBeDisplayed(pluginPath))];
+            pluginList = [
+                for ([pluginName, {pluginPath, pluginInfo}] of util.keyValues(installedPluginTable))
+                if (pluginShouldBeDisplayed(pluginPath)) [
+                    pluginInfo.iconURL, pluginName, pluginInfo.description
+                ]
+            ];
         }
 
         /* Remove already selected plugins */

--- a/content/pluginmanager.js
+++ b/content/pluginmanager.js
@@ -41,11 +41,11 @@ let ksPluginManager = (function () {
         let elem = document.createElement(name);
 
         if (attrs)
-            for (let [k, v] in Iterator(attrs))
+            for (let [k, v] of util.keyValues(attrs))
                 elem.setAttribute(k, v);
 
         if (childs)
-            for (let [, child] in Iterator(childs))
+            for (let child of childs)
                 elem.appendChild(child);
 
         return elem;
@@ -414,7 +414,7 @@ let ksPluginManager = (function () {
     function updateDisabledPluginList() {
         var disabledPlugins = [];
 
-        for (let [pluginPath, ] in Iterator(pluginInfoHolder)) {
+        for (let pluginPath of Object.keys(pluginInfoHolder)) {
             if (pluginInfoHolder[pluginPath].status === KS_PLUGIN_DISABLED) {
                 disabledPlugins.push(pluginPath);
             }

--- a/content/preference.js
+++ b/content/preference.js
@@ -91,7 +91,7 @@ var ksPreference = {
     setPluginUpdaterIntervalFieldState: function (enabled) {
         let box = document.getElementById("plugin-updater-interval");
 
-        for (let [, elem] in Iterator(box.childNodes))
+        for (let elem of box.childNodes)
             elem.disabled = !enabled;
     },
 
@@ -966,7 +966,7 @@ var ksPreference = {
 
         var keys = keyCustomizer.getSpecialKeys();
 
-        var maxLen = Math.max.apply(null, [str.length for (str in keys)]);
+        var maxLen = Math.max.apply(null, [for (str of Object.keys(keys)) str.length]);
         for (var key in keys)
         {
             var padding = Math.max(maxLen - key.length, 0) + 2;

--- a/content/rcwizard.js
+++ b/content/rcwizard.js
@@ -68,7 +68,7 @@
             let self = this;
 
             this.getSchemeFiles(function (files) {
-                for (let [, leaf] in Iterator(files.map(function (f) f.leafName)))
+                for (let leaf of files.map(function (f) f.leafName))
                 {
                     try
                     {

--- a/plugins/_color-theme-solarized.ks.js
+++ b/plugins/_color-theme-solarized.ks.js
@@ -86,8 +86,8 @@ let PLUGIN_INFO =
     style.js["undefined"] = color($red);
     style.js["null"]      = color($cyan);
 
-    for (let [prefix, opts] in Iterator(ooo))
-        for (let [k, v] in Iterator(opts))
+    for (let [prefix, opts] of util.keyValues(ooo))
+        for (let [k, v] of util.keyValues(opts))
             plugins.options[prefix + "." + k] = arrange(v);
 
     let colorThemeSolarized = arrange('\

--- a/plugins/_color-theme-solarized.ks.js
+++ b/plugins/_color-theme-solarized.ks.js
@@ -2,7 +2,7 @@ let PLUGIN_INFO =
         <KeySnailPlugin>
         <name>Color Theme Solarized</name>
         <description>A color scheme inspired by Solarized</description>
-        <version>0.0.2</version>
+        <version>0.0.3</version>
         <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/_color-theme-solarized.ks.js</updateURL>
         <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/_color-theme-solarized.icon.png</iconURL>
         <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/_dark-theme.ks.js
+++ b/plugins/_dark-theme.ks.js
@@ -2,7 +2,7 @@ let PLUGIN_INFO =
 <KeySnailPlugin>
     <name>Dark Theme</name>
     <description>Dark Theme for KeySnail</description>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/_dark-theme.ks.js</updateURL>
     <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/dark-theme.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/_dark-theme.ks.js
+++ b/plugins/_dark-theme.ks.js
@@ -78,8 +78,8 @@ let PLUGIN_INFO =
      style.js["undefined"] = "color:#e000a5;";
      style.js["null"]      = "color:#07d8a8;";
 
-     for (let [prefix, opts] in Iterator(ooo))
-         for (let [k, v] in Iterator(opts))
+     for (let [prefix, opts] of util.keyValues(ooo))
+         for (let [k, v] of util.keyValues(opts))
              plugins.options[prefix + "." + k] = arrange(v);
 
      let darkTheme = arrange(<><![CDATA[

--- a/plugins/_scrollet.ks.js
+++ b/plugins/_scrollet.ks.js
@@ -779,7 +779,7 @@ var PLUGIN_INFO =
     <name>Scrollet!</name>
     <description>Provides various scroll commands and mark system</description>
     <description lang="ja">強力なマークシステムと様々なスクロールコマンドを提供します</description>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
     <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/_scrollet.ks.js</updateURL>
     <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/_scrollet.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/_scrollet.ks.js
+++ b/plugins/_scrollet.ks.js
@@ -698,13 +698,14 @@ ext.add("scrollet-jump-to-mark", function (ev, arg) {
             var mode  = getCurrentMode();
 
             var current = Date.now();
-            var collection = [[marks[k].mode,
-                               k,
-                               marks[k],
-                               getElapsedTimeString(current - marks[k].date)
-                              ] for (k in marks)].sort(
-                                  function (a, b) (a[0] > b[0] ? 1 : a[0] === b[0] ? 0 : -1)
-                              );
+            var collection = [for (k of Object.keys(marks)) [
+                marks[k].mode,
+                k,
+                marks[k],
+                getElapsedTimeString(current - marks[k].date)
+            ]].sort(
+                function (a, b) (a[0] > b[0] ? 1 : a[0] === b[0] ? 0 : -1)
+            );
 
             var selectedMark;
 

--- a/plugins/_xul-growl.ks.js
+++ b/plugins/_xul-growl.ks.js
@@ -9,7 +9,7 @@ var PLUGIN_INFO =
     <name>XUL Growl</name>
     <description>Growl like interface using XUL</description>
     <description lang="ja">XUL を用いた Growl のようなインタフェース</description>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/_xul-growl.ks.js</updateURL>
     <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/_xul-growl.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/_xul-growl.ks.js
+++ b/plugins/_xul-growl.ks.js
@@ -286,7 +286,7 @@ var xulGrowl =
                                     style={panelStyle} xmlns={xulNS}/>),
 
              getIndexAndMessageByCount: function (count) {
-                 for (let [i, gm] in Iterator(this.gmList))
+                 for (let [i, gm] of util.keyValues(this.gmList))
                  {
                      if (count == gm.count)
                          return [i, gm];

--- a/plugins/builtin-commands-ext.ks.js
+++ b/plugins/builtin-commands-ext.ks.js
@@ -4,7 +4,7 @@ var PLUGIN_INFO =
     <name>組み込みコマンドをエクステ化</name>
     <description>Make builtin commands to ext</description>
     <description lang="ja">組み込みコマンドをエクステ化します</description>
-    <version>1.1</version>
+    <version>1.2</version>
     <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/builtin-commands-ext.ks.js</updateURL>
     <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/builtin-commands-ext.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/builtin-commands-ext.ks.js
+++ b/plugins/builtin-commands-ext.ks.js
@@ -125,8 +125,8 @@ function main() {
         return;
     }
 
-    for (let [, commands] in Iterator(context.ksBuiltin)) {
-        for (var name in commands) {
+    for (let commands of util.keyValues(context.ksBuiltin)) {
+        for (let name of Object.keys(commands)) {
             var ename = propertyToExtName(name);
 
 

--- a/plugins/dabbrev.ks.js
+++ b/plugins/dabbrev.ks.js
@@ -5,7 +5,7 @@ let PLUGIN_INFO =
     <name>dabbrev</name>
     <description>Generate abbreviation.</description>
     <description lang="ja">動的略語展開</description>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/dabbrev.ks.js</updateURL>
     <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/dabbrev.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/dabbrev.ks.js
+++ b/plugins/dabbrev.ks.js
@@ -123,7 +123,7 @@ let dabbrev =
 
              popup.setAttribute("ignorekeys", "true");
 
-             for (let [i, text] in Iterator(items))
+             for (let [i, text] of util.keyValues(items))
              {
                  let item = document.createElement("menuitem");
                  item.setAttribute("label", text);
@@ -370,7 +370,7 @@ let dabbrev =
              connective : /[\u30FC\u301C]/
          };
 
-         let acode = [p for ([, p] in Iterator(code))];
+         let acode = [for (p of code) p];
 
          const WORD       = 0;
          const HIRAGANA   = 1;

--- a/plugins/dmacro.ks.js
+++ b/plugins/dmacro.ks.js
@@ -5,7 +5,7 @@ let PLUGIN_INFO =
     <name>Dynamic Macro</name>
     <description>Detect duplicated manipulation. Repeat it easily.</description>
     <description lang="ja">繰り返しを検出し、簡単に再実行</description>
-    <version>0.0.4</version>
+    <version>0.0.5</version>
     <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/dmacro.ks.js</updateURL>
     <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/dmacro.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/dmacro.ks.js
+++ b/plugins/dmacro.ks.js
@@ -246,7 +246,7 @@ let dmacro =
          function play(aEvents) {
              var len = aEvents.length;
 
-             for (let [, event] in Iterator(aEvents))
+             for (let event of aEvents)
              {
                  let target  = macro.getCurrentFocusedElement();
                  let fakedEv = {originalTarget : target};

--- a/plugins/hateb-keysnail-collabo.ks.js
+++ b/plugins/hateb-keysnail-collabo.ks.js
@@ -4,7 +4,7 @@ var PLUGIN_INFO =
     <name>Hatebnail</name>
     <description>Use Hatena bookmark extension from KeySnail!</description>
     <description lang="ja">はてなブックマーク拡張を KeySnail から使おう！</description>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/hateb-keysnail-collabo.ks.js</updateURL>
     <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/hateb-keysnail-collabo.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/hateb-keysnail-collabo.ks.js
+++ b/plugins/hateb-keysnail-collabo.ks.js
@@ -232,7 +232,7 @@ function addBookMark(options) {
     const limit = 100;
 
     let tags         = hBookmark.model('Tag').findDistinctTags();
-    let filteredTags = [tag.name for ([, tag] in Iterator(tags))];
+    let filteredTags = [for (tag of tags) tag.name];
 
     let currentMsg;
 

--- a/plugins/hok.ks.js
+++ b/plugins/hok.ks.js
@@ -5,7 +5,7 @@ var PLUGIN_INFO =
     <name>HoK</name>
     <description>Hit a hint for KeySnail</description>
     <description lang="ja">キーボードでリンクを開く</description>
-    <version>1.4.4</version>
+    <version>1.4.5</version>
     <updateURL>https://github.com/mooz/keysnail/raw/master/plugins/hok.ks.js</updateURL>
     <iconURL>https://github.com/mooz/keysnail/raw/master/plugins/icon/hok.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/hok.ks.js
+++ b/plugins/hok.ks.js
@@ -482,7 +482,7 @@ function createMouseEvent(aDocument, aType, aOptions) {
         defaults[prop] = aOptions[prop];
     }
 
-    event.initMouseEvent.apply(event, [v for each(v in defaults)]);
+    event.initMouseEvent.apply(event, [for (v of defaults) v]);
 
     return event;
 }
@@ -566,7 +566,7 @@ function followRel(doc, rel, pattern) {
         doc.querySelectorAll(pOptions["follow_link_candidate_selector"])
     );
 
-    for (let [, elem] in Iterator(relLinkCandidates.reverse())) {
+    for (let elem of relLinkCandidates.reverse()) {
         if (relLinkPattern.test(elem.textContent) ||
             relLinkPattern.test(elem.alt) ||
             relLinkPattern.test(elem.title)) {
@@ -736,7 +736,7 @@ var hok = function () {
         }
 
         var hints = [];
-        for (let [hint] in Iterator(reverseHints)) {
+        for (let hint of Object.keys(reverseHints)) {
             hints.push(hint);
         }
 
@@ -897,7 +897,7 @@ var hok = function () {
         var hintSpan = doc.createElement('span');
 
         let st = hintSpan.style;
-        for (let [prop, value] in Iterator(hintBaseStyle))
+        for (let [prop, value] of util.keyValues(hintBaseStyle))
             st[formatPropertyName(prop)] = value;
         st.backgroundColor = hintColorLink;
 
@@ -1016,7 +1016,7 @@ var hok = function () {
         const hideUnmatchedHint = pOptions["hide_unmatched_hint"];
         let foundCount = 0;
 
-        for (let [hintStr, hintElem] in Iterator(hintElements)) {
+        for (let [hintStr, hintElem] of util.keyValues(hintElements)) {
             hintStr = String(hintStr);
             if (hintStr.indexOf(inputKey) === 0) {
                 if (hintStr != inputKey)
@@ -1033,7 +1033,7 @@ var hok = function () {
     }
 
     function resetHintsColor() {
-        for (let [, span] in Iterator(hintElements)) {
+        for (let span of util.values(hintElements)) {
             span.style.backgroundColor = getHintColor(span.element);
             span.style.display = "inline";
         }
@@ -1188,8 +1188,8 @@ var hok = function () {
         let currentPageURL = content.location.href;
         if (pOptions["local_queries"] && currentPageURL)
         {
-            for (let [, [targetURLPattern, localSelector, toOverride]]
-                 in Iterator(pOptions["local_queries"]))
+            for (let [targetURLPattern, localSelector, toOverride]
+                 of pOptions["local_queries"])
             {
                 if (currentPageURL.match(targetURLPattern))
                 {
@@ -1254,7 +1254,7 @@ var hok = function () {
                     try
                     {
                         // TODO: Is there a good way to do this?
-                        for (let [, hintElem] in Iterator(hintElements))
+                        for (let hintElem of util.values(hintElements))
                         {
                             if (supressUniqueFire)
                                 hintElem.element.focus();

--- a/plugins/keyspawn.ks.js
+++ b/plugins/keyspawn.ks.js
@@ -74,7 +74,7 @@ let KeySpawn = {
     },
 
     withTempFiles: function (f, self) {
-        let tmpFiles = [i for (i in util.range(0, f.length))].map(this.createTempFile);
+        let tmpFiles = [for (i of util.range(0, f.length)) i].map(this.createTempFile);
 
         try {
             return f.apply(self || this, tmpFiles);

--- a/plugins/keyspawn.ks.js
+++ b/plugins/keyspawn.ks.js
@@ -3,7 +3,7 @@ const PLUGIN_INFO =
     <name>KeySpawn</name>
     <description>Spawn</description>
     <description lang="ja">外部コマンドを実行</description>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/keyspawn.ks.js</updateURL>
     <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/keyspawn.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/kkk.ks.js
+++ b/plugins/kkk.ks.js
@@ -127,12 +127,12 @@ let kkk =
              },
 
              start: function () {
-                 for (let [, type] in Iterator(eventType))
+                 for (let type of eventType)
                      window.addEventListener(type, preventEvent, true);
              },
 
              stop: function () {
-                 for (let [, type] in Iterator(eventType))
+                 for (let type of eventType)
                      window.removeEventListener(type, preventEvent, true);
              }
          };

--- a/plugins/kkk.ks.js
+++ b/plugins/kkk.ks.js
@@ -5,7 +5,7 @@ var PLUGIN_INFO =
     <name>KKK</name>
     <description>Kill keyup and keydown event</description>
     <description lang="ja">keyup, keydown イベントが特定のサイトへ渡らないように</description>
-    <version>0.0.4</version>
+    <version>0.0.5</version>
     <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/kkk.ks.js</updateURL>
     <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/kkk.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/kungfloo.ks.js
+++ b/plugins/kungfloo.ks.js
@@ -5,7 +5,7 @@ let PLUGIN_INFO =
     <name>kungfloo</name>
     <description>Manipulate Tombloo from KeySnail</description>
     <description lang="ja">KeySnail から Tombloo を操作</description>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
     <updateURL>https://github.com/mooz/keysnail/raw/master/plugins/kungfloo.ks.js</updateURL>
     <iconURL>https://github.com/mooz/keysnail/raw/master/plugins/icon/kungfloo.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/kungfloo.ks.js
+++ b/plugins/kungfloo.ks.js
@@ -222,8 +222,9 @@ let kungfloo = (function () {
     function getActions() {
         let actions = Tombloo.Service.actions;
 
-        return [actions[name] for ([, name] in Iterator(actions.names))
-                              if (actions[name] && typeof actions[name].execute === "function")];
+        return [for (name of actions.names)
+                if (actions[name] && typeof actions[name].execute === "function")
+                  actions[name]];
     }
 
     function getContext(target) {
@@ -283,7 +284,7 @@ let kungfloo = (function () {
                 var extension = Tombloo.Service.check(context);
             }
 
-            let candidates = [[e, e.ICON, e.name] for ([, e] in Iterator(extensions))];
+            let candidates = [for (e of extensions) [e, e.ICON, e.name]];
 
             function share(extension, dialog) {
                 Tombloo.Service.share(context, extension, dialog);

--- a/plugins/metaplus.ks.js
+++ b/plugins/metaplus.ks.js
@@ -104,12 +104,12 @@ function getOption(aName) {
         return aName in optionsDefaultValue ? optionsDefaultValue[aName] : undefined;
 }
 
-for (let [mode, keymap] in Iterator(key.keyMapHolder))
+for (let [mode, keymap] of util.keyValues(key.keyMapHolder))
 {
     if (!keymap)
         continue;
 
-    for (let [k, f] in Iterator(keymap))
+    for (let [k, f] of util.keyValues(keymap))
     {
         let matched = k.match(/^(C-)?M-(.+)/);
         if (matched)

--- a/plugins/metaplus.ks.js
+++ b/plugins/metaplus.ks.js
@@ -3,7 +3,7 @@ var PLUGIN_INFO =
     <name>MetaPlus</name>
     <description>Make ESC behave as Meta</description>
     <description lang="ja">ESC キーを Meta キーとして</description>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <updateURL>http://github.com/mooz/keysnail/raw/master/plugins/metaplus.ks.js</updateURL>
     <iconURL>http://github.com/mooz/keysnail/raw/master/plugins/icon/metaplus.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/yet-another-twitter-client-keysnail.ks.js
+++ b/plugins/yet-another-twitter-client-keysnail.ks.js
@@ -12,7 +12,7 @@ const PLUGIN_INFO =
     <name>Yet Another Twitter Client KeySnail</name>
     <description>Make KeySnail behave like Twitter client</description>
     <description lang="ja">KeySnail を Twitter クライアントに</description>
-    <version>3.2.2</version>
+    <version>3.2.3</version>
     <updateURL>https://github.com/mooz/keysnail/raw/master/plugins/yet-another-twitter-client-keysnail.ks.js</updateURL>
     <iconURL>https://github.com/mooz/keysnail/raw/master/plugins/icon/yet-another-twitter-client-keysnail.icon.png</iconURL>
     <author mail="stillpedant@gmail.com" homepage="http://d.hatena.ne.jp/mooz/">mooz</author>

--- a/plugins/yet-another-twitter-client-keysnail.ks.js
+++ b/plugins/yet-another-twitter-client-keysnail.ks.js
@@ -524,11 +524,11 @@ const $U = {
         let elem = document.createElement(name);
 
         if (attrs)
-            for (let [k, v] in Iterator(attrs))
+            for (let [k, v] of util.keyValues(attrs))
                 elem.setAttribute(k, v);
 
         if (childs)
-            for (let [, v] in Iterator(childs))
+            for (let v of childs)
                 elem.appendChild(v);
 
         return elem;
@@ -1048,7 +1048,7 @@ OAuth.prototype = {
         if (options.parameters && message.method === "POST")
         {
             outer:
-            for (let [, params] in Iterator(options.parameters))
+            for (let params of options.parameters)
             {
                 for (let i = 0; i < message.parameters; ++i)
                 {
@@ -1112,13 +1112,13 @@ const twitterAPI = {
 
         let action = proto.action;
 
-        for (let [k, v] in Iterator(args))
+        for (let [k, v] of util.keyValues(args))
             if (typeof v !== "undefined")
                 action = action.replace(util.format("{%s}", k), $U.encodeOAuth(v), "g");
 
-        let query = [k + "=" + $U.encodeOAuth(v)
-                     for ([k, v] in Iterator(params))
-                     if (typeof v !== "undefined")].join("&");
+        let query = [for (kv of util.keyValues(params))
+                     if (typeof kv[1] !== "undefined")
+                       kv[0] + "=" + $U.encodeOAuth(kv[1])].join("&");
         if (query.length)
             action += (action.indexOf("?") < 0 ? "?" : "&") + query;
 
@@ -1435,7 +1435,7 @@ var twitterClient =
             createParams: function () {
                 let params = {};
                 if (this.params)
-                    [[k, v] for ([k, v] in Iterator(this.params))].forEach(
+                    [for (kv of util.keyValues(this.params)) kv].forEach(
                         function ([k, v]) params[k] = v
                     );
                 return params;
@@ -1504,9 +1504,9 @@ var twitterClient =
                 let { action } = this;
 
                 if (context.params) {
-                    let query = [k + "=" + $U.encodeOAuth(v)
-                                 for ([k, v] in Iterator(context.params))
-                                 if (typeof v !== "undefined")].join("&");
+                    let query = [for (kv of util.keyValues(context.params))
+                                 if (typeof kv[1] !== "undefined")
+                                 kv[0] + "=" + $U.encodeOAuth(kv[1])].join("&");
                     if (query.length)
                         action += (action.indexOf("?") < 0 ? "?" : "&") + query;
                 }
@@ -1629,7 +1629,7 @@ var twitterClient =
                 window.addEventListener("unload", function () {
                     self.stop();
 
-                    for (let [, win] in Iterator(Notifier.getBrowserWindows()))
+                    for (let win of Notifier.getBrowserWindows())
                     {
                         try
                         {
@@ -1792,7 +1792,7 @@ var twitterClient =
         if (!share.twitterTrackingInfo)
             share.twitterTrackingInfo = persist.restore("yatck_tracking_info") || {};
 
-        for (let [name, info] in Iterator(share.twitterTrackingInfo))
+        for (let [name, info] of util.keyValues(share.twitterTrackingInfo))
         {
             if (!share.twitterTrackingInfo[name])
                 share.twitterTrackingInfo[name] = {};
@@ -2585,7 +2585,7 @@ var twitterClient =
             let listOrigin  = document.getElementById(HEAD_LIST_ORIGIN);
             let listButtons = {};
 
-            for (let [, crawler] in Iterator(gLists))
+            for (let crawler of util.values(gLists))
             {
                 let button = document.createElement("toolbarbutton");
 
@@ -2608,7 +2608,7 @@ var twitterClient =
             let searchOrigin    = document.getElementById(HEAD_SEARCH_ORIGIN);
             let trackingButtons = {};
 
-            for (let [, crawler] in Iterator(gTrackings))
+            for (let crawler of util.values(gTrackings))
             {
                 let name    = crawler.name;
                 let keyword = crawler.nameEscaped;
@@ -3358,19 +3358,23 @@ var twitterClient =
                 return "(" + (unreadCount < 0 ? "-" : unreadCount) + ") " + crawler.name;
             }
 
-            let lists = [[TAG_ICON, crawlerToLabel(crawler), (function (name) {
-                                               return function () {
-                                                   self.showCrawledListStatuses.apply(null, name.split("/"));
-                                               };
-                                           })(name)]
-                         for ([name, crawler] in Iterator(gLists))];
+            let lists = [
+              for (kv of util.keyValues(gLists))
+                [TAG_ICON, crawlerToLabel(kv[1]), (function (name) {
+                  return function () {
+                    self.showCrawledListStatuses.apply(null, name.split("/"));
+                  };
+                })(kv[0])]
+            ];
 
-            let trackings = [[SEARCH_ICON, crawlerToLabel(crawler), (function (name) {
-                                               return function () {
-                                                   self.showCrawledTrackingStatuses.call(null, name);
-                                               };
-                                           })(name)]
-                         for ([name, crawler] in Iterator(gTrackings))];
+            let trackings = [
+              for (kv of util.keyValues(gTrackings))
+                [SEARCH_ICON, crawlerToLabel(kv[1]), (function (name) {
+                  return function () {
+                    self.showCrawledTrackingStatuses.call(null, name);
+                  };
+                })(kv[0])]
+            ];
 
             const ACT_ROW = 2;
 
@@ -3584,7 +3588,7 @@ var twitterClient =
             ["entities", "media"].forEach(function (entityContainerName) {
                 let entityContainer = status[entityContainerName];
                 if (status[entityContainerName]) {
-                    for (let [entityName, entity] in Iterator(entityContainer)) {
+                    for (let [entityName, entity] of util.keyValues(entityContainer)) {
                         entities[entityName] = entity;
                     }
                 }
@@ -3610,7 +3614,7 @@ var twitterClient =
                     retweetedMessageNode.removeChild(retweetedMessageNode.firstChild);
                 }
 
-                for (let [, childNode] in Iterator(newChildren)) {
+                for (let childNode of newChildren) {
                     retweetedMessageNode.appendChild(childNode);
                 }
 
@@ -3637,7 +3641,9 @@ var twitterClient =
         }
 
         function getSortedEntitiesWithType(entities) {
-            let sortedEntities = [[entityType, entityList] for ([entityType, entityList] in Iterator(entities))].reduce(
+            let sortedEntities = [
+              for (kv of util.keyValues(entities)) kv
+            ].reduce(
                 function (entityWithTypes, [entityType, entityList]) {
                     return entityWithTypes.concat(entityList.map(function (entity) {
                         return {
@@ -3993,7 +3999,7 @@ var twitterClient =
             if (!gStatuses.cache)
                 return;
 
-            for (let [, status] in Iterator(gStatuses.cache))
+            for (let status of gStatuses.cache)
                 if (status.id_str === aId)
                     proc(status);
         }
@@ -4377,7 +4383,7 @@ var twitterClient =
             updateListButton: function () {
                 let listButtons = my.twitterClientHeader.listButtons;
 
-                for (let [, crawler] in Iterator(gLists))
+                for (let crawler of gLists)
                 {
                     if (crawler.name in listButtons && crawler.cache && crawler.cache.length)
                     {
@@ -4391,7 +4397,7 @@ var twitterClient =
             updateTrackingButton: function () {
                 let trackingButtons = my.twitterClientHeader.trackingButtons;
 
-                for (let [, crawler] in Iterator(gTrackings))
+                for (let crawler of util.values(gTrackings))
                 {
                     if (crawler.name in trackingButtons && crawler.cache && crawler.cache.length)
                     {
@@ -4569,7 +4575,7 @@ var twitterClient =
 
         if (pOptions["automatically_begin_list"])
         {
-            for (let [, crawler] in Iterator(gLists))
+            for (let crawler of gLists)
             {
                 if (crawler.cache)
                     continue;
@@ -4581,7 +4587,7 @@ var twitterClient =
 
         if (pOptions["automatically_begin_tracking"])
         {
-            for (let [, crawler] in Iterator(gTrackings))
+            for (let crawler of util.keyValues(gTrackings))
             {
                 if (crawler.cache)
                     continue;

--- a/share/WikiParser.js
+++ b/share/WikiParser.js
@@ -109,7 +109,6 @@ WikiParser.prototype = {
         }
     },
     parse: function(){
-        var ite = Iterator(this.lines);
         var num, line, indent;
         var currentIndent = 0, indentList = [0], nest=0;
         var prevMode = "";
@@ -117,7 +116,7 @@ WikiParser.prototype = {
         var stack = [];
         var prevNode;
         //try {
-        for ([num, line] in ite){
+        for ([num, line] of util.keyValues(this.lines)){
             [,indent, line] = line.match(/^(\s*)(.*)\s*$/);
             currentIndent = indent.length;
             var prevIndent = indentList[indentList.length -1];

--- a/share/share.js
+++ b/share/share.js
@@ -243,7 +243,7 @@ function hookApplicationQuit() {
 
     quitObserver.prototype = {
         observe: function(subject, topic, data) {
-            for (let [name, obj] in Iterator(persist.registeredObjects))
+            for (let [name, obj] of util.keyValues(persist.registeredObjects))
             {
                 persist.preserve(obj, name);
             }

--- a/stub/hit-a-hint.ks.js
+++ b/stub/hit-a-hint.ks.js
@@ -396,11 +396,11 @@ var ksHah = new function () {
         let type = elem.type;
 
         if (elem instanceof HTMLInputElement && /(submit|button|reset)/.test(type)) {
-            return [elem.value, false];   
+            return [elem.value, false];
         }
         else
         {
-            for (let [, option] in Iterator(options["hintinputs"].split(",")))
+            for (let option of options["hintinputs"].split(","))
             {
                 if (option == "value")
                 {
@@ -641,7 +641,7 @@ var ksHah = new function () {
         let activeHint = hintNumber || 1;
         validHints = [];
 
-        for (let [,{ doc: doc, start: start, end: end }] in Iterator(docs))
+        for (let { doc: doc, start: start, end: end } of docs)
         {
             let [scrollX, scrollY] = getBodyOffsets(doc);
 
@@ -701,7 +701,7 @@ var ksHah = new function () {
         {
             let css = [];
             // FIXME: Broken for imgspans.
-            for (let [, { doc: doc }] in Iterator(docs))
+            for (let { doc: doc } of docs)
             {
                 for (let elem in evaluateXPath("//*[@keysnail:highlight and @number]", doc))
                 {
@@ -727,7 +727,7 @@ var ksHah = new function () {
     {
         let firstElem = validHints[0] || null;
 
-        for (let [,{ doc: doc, start: start, end: end }] in Iterator(docs))
+        for (let { doc: doc, start: start, end: end } of docs)
         {
             for (let elem in evaluateXPath("//*[@keysnail:highlight='hints']", doc))
                 elem.parentNode.removeChild(elem);
@@ -987,7 +987,7 @@ var ksHah = new function () {
             function stringsAtBeginningOfWords(strings, words, allowWordOverleaping)
             {
                 let strIdx = 0;
-                for (let [, word] in Iterator(words))
+                for (let word of words)
                 {
                     if (word.length == 0)
                         continue;
@@ -1126,7 +1126,7 @@ var ksHah = new function () {
     //                 completer: function (context)
     //                 {
     //                     context.compare = function () 0;
-    //                     context.completions = [[k, v.prompt] for ([k, v] in Iterator(hintModes))];
+    //                     context.completions = [for (k of hintModes) [k, hintModes[k].prompt]];
     //                 },
     //                 onChange: function () { modes.pop(); },
     //                 onCancel: function (arg) { arg && setTimeout(function () hints.show(arg), 0); }

--- a/stub/yah.ks.js
+++ b/stub/yah.ks.js
@@ -242,7 +242,7 @@ function createMouseEvent(aDocument, aType, aOptions) {
         defaults[prop] = aOptions[prop];
     }
 
-    event.initMouseEvent.apply(event, [v for each(v in defaults)]);
+    event.initMouseEvent.apply(event, [for (v of defaults)] v);
 
     return event;
 }


### PR DESCRIPTION
Firefox 46 removes following object/syntax.

* `Iterator` object (replaced by ES 2016's iterator protocol)
* Old array comprehension syntax (replaced by ES 2016's array comprehension syntax)

This PR replaces those with new for-of syntax.