### PR TITLE
kkk: Fix broken ctrl-tab behavior

### DIFF
--- a/plugins/kkk.ks.js
+++ b/plugins/kkk.ks.js
@@ -105,10 +105,14 @@ let kkk =
              }
          }
 
+         function isCtrlTabKeystroke() {
+             return key.ctrlKey && key.which == 9;
+         }
+
          function preventEvent(ev) {
              if (self.status || (self.multiSequence && key.currentKeySequence.length > 0))
              {
-                 if (!key.suspended && !key.escapeCurrentChar)
+                 if (!key.suspended && !key.escapeCurrentChar && !self.isCtrlTabKeystroke())
                  {
                      if (!isEventOnEditor(ev) || self.isKillEditorSite) {
                          ev.stopPropagation();


### PR DESCRIPTION
The "switch window" functionality is broken on sites where KKK is
enabled. The dialog pops up and multiple tab keypresses are also
recognized but when you release the ctrl-tab keys, nothing happens.
It appears that KKK is eating the "keyup" event.

This commit prevents KKK from hooking into events when ctrl-tab is pressed.
